### PR TITLE
Add autoload cookie so that autoloads are generated

### DIFF
--- a/extra/gvpr-mode.el
+++ b/extra/gvpr-mode.el
@@ -51,6 +51,7 @@
 
 (require 'generic-x)
 
+;;;###autoload
 (define-generic-mode
   'gvpr-mode                      ;; name of the mode
   '("//")                         ;; comments


### PR DESCRIPTION
I installed gvpr-mode via ELPA, and this would at least allow M-x gvpr-mode RET to work.  Also nice would be adding something like

    ;;;###autoload (add-to-list 'auto-mode-alist '("\\.gvpr$" . gvpr-mode))

so that opening a `gvpr` file would just work as well.  But that seems like duplication and might get out of sync.  I'd be happy to open another pull request with that if you would like.