### PR TITLE
Recognize BEG_G in gvpr-mode

### DIFF
--- a/extra/gvpr-mode.el
+++ b/extra/gvpr-mode.el
@@ -62,7 +62,7 @@
   '(                              ;; other syntax-colored terms
     ;; clauses
     ("\\<BEGIN\\>"   . 'font-lock-preprocessor-face)
-    ("\\<BEGIN_G\\>" . 'font-lock-preprocessor-face)
+    ("\\<BEG\\(?:IN\\)?_G\\>" . 'font-lock-preprocessor-face)
     ("\\<N\\>"       . 'font-lock-preprocessor-face)
     ("\\<E\\>"       . 'font-lock-preprocessor-face)
     ("\\<END_G\\>"   . 'font-lock-preprocessor-face)


### PR DESCRIPTION
According to gvpr(1) man page it is BEG_G not BEGIN_G.  Support both in case BEGIN_G is supported by gvpr somewhere.